### PR TITLE
Sending IR command multiple times when holding a button

### DIFF
--- a/infrared_remote_app.c
+++ b/infrared_remote_app.c
@@ -472,9 +472,15 @@ int32_t infrared_remote_app(void* p) {
 					if (is_transmitting) {
 						infrared_worker_tx_stop(app->infrared_worker);
 					}
-					InfraredMessage* message = infrared_signal_get_message(active_signal);
 
-					infrared_worker_set_decoded_signal(app->infrared_worker, message);
+					if(infrared_signal_is_raw(active_signal)) {
+						InfraredRawSignal* raw_signal = infrared_signal_get_raw_signal(active_signal);
+						infrared_worker_set_raw_signal(app->infrared_worker, raw_signal->timings, raw_signal->timings_size);
+					} else {
+						InfraredMessage* message = infrared_signal_get_message(active_signal);
+						infrared_worker_set_decoded_signal(app->infrared_worker, message);
+					}
+
 					infrared_worker_tx_set_get_signal_callback(app->infrared_worker, infrared_worker_tx_get_signal_steady_callback, app);
 
 					infrared_worker_tx_start(app->infrared_worker);

--- a/infrared_remote_app.c
+++ b/infrared_remote_app.c
@@ -1,6 +1,8 @@
 #include <furi.h>
 #include <furi_hal.h>
 
+#include <infrared_worker.h>
+
 #include <gui/gui.h>
 #include <input/input.h>
 #include <dialogs/dialogs.h>
@@ -30,6 +32,7 @@ typedef struct {
 	FuriString* left_hold_button;
 	FuriString* right_hold_button;
 	FuriString* ok_hold_button;
+	InfraredWorker* infrared_worker;
 }IRApp;
 
 // Screen is 128x64 px
@@ -110,6 +113,7 @@ int32_t infrared_remote_app(void* p) {
 	app->right_hold_button = furi_string_alloc();
 	app->ok_hold_button = furi_string_alloc();
 	app->view_port = view_port_alloc();
+	app->infrared_worker = infrared_worker_alloc();
 
 	// Configure view port
 	view_port_draw_callback_set(app->view_port, app_draw_callback, app);
@@ -177,6 +181,9 @@ int32_t infrared_remote_app(void* p) {
 	InfraredSignal* left_hold_signal = infrared_signal_alloc();
 	InfraredSignal* right_hold_signal = infrared_signal_alloc();
 	InfraredSignal* ok_hold_signal = infrared_signal_alloc();
+
+	InfraredSignal* active_signal = NULL;
+	bool is_transmitting = false;
 
 	bool up_enabled = false;
 	bool down_enabled = false;
@@ -379,43 +386,37 @@ int32_t infrared_remote_app(void* p) {
 					switch(event.key) {
 					case InputKeyUp:
 						if(up_enabled){
-							infrared_signal_transmit(up_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = up_signal;
 							FURI_LOG_I(TAG, "up");
 						}
 						break;
 					case InputKeyDown:
 						if(down_enabled){
-							infrared_signal_transmit(down_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = down_signal;
 							FURI_LOG_I(TAG, "down");
 						}
 						break;
 					case InputKeyRight:
 						if(right_enabled){
-							infrared_signal_transmit(right_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = right_signal;
 							FURI_LOG_I(TAG, "right");
 						}
 						break;
 					case InputKeyLeft:
 						if(left_enabled){
-							infrared_signal_transmit(left_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = left_signal;
 							FURI_LOG_I(TAG, "left");
 						}
 						break;
 					case InputKeyOk:
 						if(ok_enabled){
-							infrared_signal_transmit(ok_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = ok_signal;
 							FURI_LOG_I(TAG, "ok");
 						}
 						break;
 					case InputKeyBack:
 						if(back_enabled){
-							infrared_signal_transmit(back_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = back_signal;
 							FURI_LOG_I(TAG, "back");
 						}
 						break;
@@ -428,36 +429,31 @@ int32_t infrared_remote_app(void* p) {
 					switch(event.key) {
 						case InputKeyUp:
 						if(up_hold_enabled){
-							infrared_signal_transmit(up_hold_signal);
-							notification_message(notification, &sequence_blink_start_magenta);
+							active_signal = up_hold_signal;
 							FURI_LOG_I(TAG, "up!");
 						}
 						break;
 						case InputKeyDown:
 							if(down_hold_enabled){
-								infrared_signal_transmit(down_hold_signal);
-								notification_message(notification, &sequence_blink_start_magenta);
+								active_signal = down_hold_signal;
 								FURI_LOG_I(TAG, "down!");
 							}
 							break;
 						case InputKeyRight:
 							if(right_hold_enabled){
-								infrared_signal_transmit(right_hold_signal);
-								notification_message(notification, &sequence_blink_start_magenta);
+								active_signal = right_hold_signal;
 								FURI_LOG_I(TAG, "right!");
 							}
 							break;
 						case InputKeyLeft:
 							if(left_hold_enabled){
-								infrared_signal_transmit(left_hold_signal);
-								notification_message(notification, &sequence_blink_start_magenta);
+								active_signal = left_hold_signal;
 								FURI_LOG_I(TAG, "left!");
 							}
 							break;
 						case InputKeyOk:
 							if(ok_hold_enabled){
-								infrared_signal_transmit(ok_hold_signal);
-								notification_message(notification, &sequence_blink_start_magenta);
+								active_signal = ok_hold_signal;
 								FURI_LOG_I(TAG, "ok!");
 							}
 							break;
@@ -465,8 +461,25 @@ int32_t infrared_remote_app(void* p) {
 							running = false;
 							break;
 					}
-				}else if(event.type == InputTypeRelease){
+				}else if(event.type == InputTypeRelease && is_transmitting){
 					notification_message(notification, &sequence_blink_stop);
+					infrared_worker_tx_stop(app->infrared_worker);
+					is_transmitting = false;
+					active_signal = NULL;
+				}
+
+				if(active_signal != NULL && (event.type == InputTypeShort || event.type == InputTypeLong)) {
+					if (is_transmitting) {
+						infrared_worker_tx_stop(app->infrared_worker);
+					}
+					InfraredMessage* message = infrared_signal_get_message(active_signal);
+
+					infrared_worker_set_decoded_signal(app->infrared_worker, message);
+					infrared_worker_tx_set_get_signal_callback(app->infrared_worker, infrared_worker_tx_get_signal_steady_callback, app);
+
+					infrared_worker_tx_start(app->infrared_worker);
+					notification_message(notification, &sequence_blink_start_magenta);
+					is_transmitting = true;
 				}
 			}
 		}
@@ -484,6 +497,12 @@ int32_t infrared_remote_app(void* p) {
 	furi_string_free(app->left_hold_button);
 	furi_string_free(app->right_hold_button);
 	furi_string_free(app->ok_hold_button);
+
+	if (is_transmitting) {
+		infrared_worker_tx_stop(app->infrared_worker);
+		notification_message(notification, &sequence_blink_stop);
+	}
+	infrared_worker_free(app->infrared_worker);
 
 	infrared_remote_free(remote);
 	view_port_enabled_set(app->view_port, false);


### PR DESCRIPTION
Implemented the option to send the IR command multiple times when long pressing. Useful if you use volume or brightness control for UPHOLD and DOWNHOLD.
This uses the same library as the normal IR App and should therefore work the same as long pressing the button in that App